### PR TITLE
fix: web terminal for argocd pods

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -94,3 +94,4 @@ server:
     annotations:
       ingress.pomerium.io/allow_any_authenticated_user: 'true'
       ingress.pomerium.io/pass_identity_headers: 'true'
+      ingress.pomerium.io/allow_websockets: 'true'


### PR DESCRIPTION
enabled websocket support within pomerium. Timeout is set to 5mins by default. Nginx appeared to have a 60s timeout. So it should be better than it was before. We may want to increase it if we get complaints from developers for the sessions being too short.