### PR TITLE
feat: allowing argocd apps to be defined in any namespace rather than just glueops-core (argocd installation namespace)

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -10,6 +10,8 @@ redis-ha:
 # @ignored
 controller:
   replicas: 1
+  extraArgs:
+    - --application-namespaces=*
 # @ignored
 repoServer:
   autoscaling:
@@ -70,6 +72,9 @@ configs:
       placeholder_argocd_rbac_policies
   # @ignored
 server:
+  # @ignored
+  extraArgs:
+    - --application-namespaces=*
   # @ignored
   autoscaling:
     enabled: true


### PR DESCRIPTION
ref: https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/