### PR TITLE
hotfix: increase repo server replicas to reduce load on application-controller as its limited to just one replica

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -47,7 +47,8 @@ repoServer:
     enabled: true
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 6
+    maxReplicas: 8
 # @ignored
 applicationSet:
   metrics:


### PR DESCRIPTION
### **User description**
hotfix: increase repo server replicas to reduce load on application-controller as its limited to just one replica


___

### **PR Type**
enhancement


___

### **Description**
- Increased the `minReplicas` for the repo server from 2 to 6 to handle higher load.
- Introduced `maxReplicas` with a value of 8 to cap the scaling and manage resource usage effectively.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd.yaml.tpl</strong><dd><code>Increase Repo Server Scalability in ArgoCD Configuration</code>&nbsp; </dd></summary>
<hr>

argocd.yaml.tpl
<li>Increased the minimum number of replicas for the repo server from 2 to <br>6.<br> <li> Set the maximum number of replicas for the repo server to 8.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/docs-argocd/pull/22/files#diff-162fd251153ae656aab6a456eaf4ea8f18be463dc6a125236d7dde923e807be0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

