### PR TITLE
fix: increase repo server replicas to reduce load on application-controller as its limited to just one replica

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -47,7 +47,8 @@ repoServer:
     enabled: true
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 6
+    maxReplicas: 8
 # @ignored
 applicationSet:
   metrics:

--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -36,6 +36,7 @@ redis-ha:
       effect: "NoSchedule"
 # @ignored
 controller:
+  priorityClassName: "system-cluster-critical"
   metrics:
     enabled: true
   replicas: 1
@@ -49,6 +50,26 @@ repoServer:
     enabled: true
     minReplicas: 6
     maxReplicas: 8
+  pdb:
+    enabled: true
+    minAvailable: 2
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: argocd-repo-server
+          topologyKey: kubernetes.io/hostname
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - argocd-application-controller
+        topologyKey: kubernetes.io/hostname
 # @ignored
 applicationSet:
   metrics:


### PR DESCRIPTION
### **User description**
fix: increase repo server replicas to reduce load on application-controller as its limited to just one replica


___

### **PR Type**
enhancement


___

### **Description**
- Increased the minimum number of replicas for the repo server from 2 to 6 to improve load distribution.
- Set a maximum of 8 replicas for the repo server to prevent excessive resource usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd.yaml.tpl</strong><dd><code>Enhance Repo Server Scalability in ArgoCD Configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

argocd.yaml.tpl
<li>Increased the minimum number of replicas for the repo server from 2 to <br>6.<br> <li> Added a maximum limit of 8 replicas for the repo server.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/docs-argocd/pull/23/files#diff-162fd251153ae656aab6a456eaf4ea8f18be463dc6a125236d7dde923e807be0">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

