### PR TITLE
fix: scheduling so that application-controller and reposerver aren't on the same nodes

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -36,6 +36,7 @@ redis-ha:
       effect: "NoSchedule"
 # @ignored
 controller:
+  priorityClassName: "system-cluster-critical"
   metrics:
     enabled: true
   replicas: 1
@@ -49,6 +50,26 @@ repoServer:
     enabled: true
     minReplicas: 6
     maxReplicas: 8
+  pdb:
+    enabled: true
+    minAvailable: 2
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: argocd-repo-server
+          topologyKey: kubernetes.io/hostname
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - argocd-application-controller
+        topologyKey: kubernetes.io/hostname
 # @ignored
 applicationSet:
   metrics:


### PR DESCRIPTION
### **User description**
fix: scheduling so that application-controller and reposerver aren't on the same nodes


___

### **PR Type**
enhancement


___

### **Description**
- Added a `priorityClassName` to the `controller` to mark it as critical within the cluster.
- Implemented a Pod Disruption Budget (PDB) for the `repoServer` to ensure availability during disruptions.
- Configured `podAntiAffinity` for the `repoServer` to prevent it from being scheduled on the same nodes as the `argocd-application-controller`, enhancing distributed reliability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd.yaml.tpl</strong><dd><code>Enhance ArgoCD Scheduling and Reliability Configurations</code>&nbsp; </dd></summary>
<hr>

argocd.yaml.tpl
<li>Added <code>priorityClassName</code> with value <code>system-cluster-critical</code> to the <br><code>controller</code> section.<br> <li> Introduced a Pod Disruption Budget (PDB) for the <code>repoServer</code> with <br><code>minAvailable</code> set to 2.<br> <li> Configured <code>podAntiAffinity</code> for <code>repoServer</code> to avoid scheduling on the <br>same nodes as <code>argocd-application-controller</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/docs-argocd/pull/24/files#diff-162fd251153ae656aab6a456eaf4ea8f18be463dc6a125236d7dde923e807be0">+21/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

