### PR TITLE
major: migrate from hosts to global.domain for helm chart updates (v7)

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -17,6 +17,7 @@ notifications:
 
 # @ignored
 global:
+  domain: ["argocd.placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain"]
   image:
     tag: "placeholder_argocd_app_version"
   tolerations:
@@ -268,7 +269,6 @@ server:
   service:
     type: ClusterIP
   ingress:
-    hosts: ["argocd.placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain"]
     # @ignored
     enabled: true
     # this public-authenticated leverages the authentication proxy (pomerium)


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Migrated from using `hosts` to `global.domain` in the Helm chart configuration.
- Added `global.domain` entry to the `global` section.
- Removed `ingress.hosts` entry from the `server` section.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd.yaml.tpl</strong><dd><code>Migrate from `hosts` to `global.domain` in Helm chart</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

argocd.yaml.tpl

<li>Added <code>global.domain</code> configuration.<br> <li> Removed <code>ingress.hosts</code> configuration.<br> <li> Updated the structure to use <code>global.domain</code> instead of <code>hosts</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/docs-argocd/pull/28/files#diff-162fd251153ae656aab6a456eaf4ea8f18be463dc6a125236d7dde923e807be0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

