### PR TITLE
fix: global.domain

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -17,7 +17,7 @@ notifications:
 
 # @ignored
 global:
-  domain: ["argocd.placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain"]
+  domain: "argocd.placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain"
   image:
     tag: "placeholder_argocd_app_version"
   tolerations:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the `global.domain` field in `argocd.yaml.tpl` by changing its type from a list to a string.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd.yaml.tpl</strong><dd><code>Fix `global.domain` type from list to string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

argocd.yaml.tpl

- Changed `global.domain` from a list to a string.



</details>


  </td>
  <td><a href="https://github.com/GlueOps/docs-argocd/pull/29/files#diff-162fd251153ae656aab6a456eaf4ea8f18be463dc6a125236d7dde923e807be0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

