### PR TITLE
fix: remove unused argocd health checks for old WAF code

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -195,37 +195,6 @@ configs:
       end
       return hs
     # @ignored
-    resource.customizations.health.metacontroller.glueops.dev_WebApplicationFirewall:
-      hs = {}
-      if obj.status then
-          if obj.status.HEALTHY == "True" then
-              hs.status = "Healthy"
-              hs.message = "WebApplicationFirewall is healthy"
-          else
-              hs.status = "Degraded"
-              hs.message = "WebApplicationFirewall is not healthy"
-          end
-      else
-          hs.status = "Progressing"
-          hs.message = "WebApplicationFirewall is initializing"
-      end
-      return hs
-    # @ignored
-    resource.customizations.health.metacontroller.glueops.dev_WebApplicationFirewallWebACL:
-      hs = {}
-      if obj.status then
-          if obj.status.HEALTHY == "True" then
-              hs.status = "Healthy"
-              hs.message = "WebApplicationFirewallWebACL is healthy"
-          else
-              hs.status = "Degraded"
-              hs.message = "WebApplicationFirewallWebACL is not healthy"
-          end
-      else
-          hs.status = "Progressing"
-          hs.message = "WebApplicationFirewallWebACL is initializing"
-      end
-      return hs
     url: "https://argocd.placeholder_cluster_environment.placeholder_tenant_key.placeholder_glueops_root_domain"
     # -- To create a clientID and clientSecret please reference: https://github.com/GlueOps/github-oauth-apps
     # This dex.config is to create a GitHub connector for SSO to ArgoCD.


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Removed unused ArgoCD health checks related to the old Web Application Firewall (WAF) code.
- Deleted specific health customization entries for `metacontroller.glueops.dev_WebApplicationFirewall` and `metacontroller.glueops.dev_WebApplicationFirewallWebACL`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>argocd.yaml.tpl</strong><dd><code>Remove unused ArgoCD health checks for WAF</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

argocd.yaml.tpl

<li>Removed unused ArgoCD health checks for WebApplicationFirewall.<br> <li> Deleted health customization for <br><code>metacontroller.glueops.dev_WebApplicationFirewall</code>.<br> <li> Deleted health customization for <br><code>metacontroller.glueops.dev_WebApplicationFirewallWebACL</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/docs-argocd/pull/36/files#diff-162fd251153ae656aab6a456eaf4ea8f18be463dc6a125236d7dde923e807be0">+0/-31</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information