### PR TITLE
fix: affinity settings for argocd app controller to prefer not being on repo server nodes when a dedicated app controller node is available

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -131,14 +131,15 @@ repoServer:
             matchLabels:
               app.kubernetes.io/name: argocd-repo-server
           topologyKey: kubernetes.io/hostname
-      requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-          - key: app.kubernetes.io/name
-            operator: In
-            values:
-            - argocd-application-controller
-        topologyKey: kubernetes.io/hostname
+      - weight: 50
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+              - argocd-application-controller
+          topologyKey: kubernetes.io/hostname
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:


### PR DESCRIPTION
…on repo server nodes when a dedicated app controller node is available