### PR TITLE
Consolidate ArgoCD node pinning into chart global.affinity

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -41,6 +41,14 @@ redis:
   exporter:
     image:
       repository: "ghcr.repo.gpkg.io/oliver006/redis_exporter"
+# redisSecretInit is a pre-install/pre-upgrade hook Job added in newer argo-cd
+# chart majors (v8/v9). It inherits global.tolerations but no node targeting,
+# so pin it explicitly to keep it on the glueops-platform nodes. (No-op on the
+# currently pinned 5.50.0 chart, which has no redisSecretInit component.)
+# @ignored
+redisSecretInit:
+  nodeSelector:
+    glueops.dev/role: "glueops-platform"
 redis-ha:
   image:
     repository: "ecr.repo.gpkg.io/docker/library/redis"

--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -5,6 +5,8 @@ crds:
 notifications:
   metrics:
     enabled: true
+  nodeSelector:
+    glueops.dev/role: "glueops-platform"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -160,6 +162,8 @@ applicationSet:
   metrics:
     enabled: true
   replicas: 2
+  nodeSelector:
+    glueops.dev/role: "glueops-platform"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -233,6 +237,9 @@ configs:
       placeholder_argocd_rbac_policies
   # @ignored
 server:
+  # @ignored
+  nodeSelector:
+    glueops.dev/role: "glueops-platform"
   # @ignored
   affinity:
     nodeAffinity:

--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -92,7 +92,25 @@ controller:
           - key: "glueops.dev/role"
             operator: In
             values:
+            - "glueops-platform-argocd-app-controller"
             - "glueops-platform"
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: "glueops.dev/role"
+            operator: In
+            values:
+            - "glueops-platform-argocd-app-controller"
+  tolerations:
+    - key: "glueops.dev/role"
+      operator: "Equal"
+      value: "glueops-platform-argocd-app-controller"
+      effect: "NoSchedule"
+    - key: "glueops.dev/role"
+      operator: "Equal"
+      value: "glueops-platform"
+      effect: "NoSchedule"
   metrics:
     enabled: true
   replicas: 1
@@ -109,6 +127,8 @@ repoServer:
   pdb:
     enabled: true
     minAvailable: 2
+  nodeSelector:
+    glueops.dev/role: "glueops-platform"
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -87,25 +87,7 @@ controller:
           - key: "glueops.dev/role"
             operator: In
             values:
-            - "glueops-platform-argocd-app-controller"
             - "glueops-platform"
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        preference:
-          matchExpressions:
-          - key: "glueops.dev/role"
-            operator: In
-            values:
-            - "glueops-platform-argocd-app-controller"
-  tolerations:
-    - key: "glueops.dev/role"
-      operator: "Equal"
-      value: "glueops-platform-argocd-app-controller"
-      effect: "NoSchedule"
-    - key: "glueops.dev/role"
-      operator: "Equal"
-      value: "glueops-platform"
-      effect: "NoSchedule"
   metrics:
     enabled: true
   replicas: 1

--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -5,17 +5,6 @@ crds:
 notifications:
   metrics:
     enabled: true
-  nodeSelector:
-    glueops.dev/role: "glueops-platform"
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: "glueops.dev/role"
-            operator: In
-            values:
-            - "glueops-platform"
 
 # @ignored
 global:
@@ -28,6 +17,19 @@ global:
       operator: "Equal"
       value: "glueops-platform"
       effect: "NoSchedule"
+  # Pin every first-party argo-cd component to the glueops-platform nodes from one
+  # place: components without their own affinity inherit this preset; components that
+  # set their own affinity (e.g. controller) override it. The redis-ha subchart and the
+  # gatekeeper extraObject are not reached by global and keep their own settings.
+  affinity:
+    podAntiAffinity: soft
+    nodeAffinity:
+      type: hard
+      matchExpressions:
+        - key: "glueops.dev/role"
+          operator: In
+          values:
+            - "glueops-platform"
   logging:
     format: json
 
@@ -41,14 +43,6 @@ redis:
   exporter:
     image:
       repository: "ghcr.repo.gpkg.io/oliver006/redis_exporter"
-# redisSecretInit is a pre-install/pre-upgrade hook Job added in newer argo-cd
-# chart majors (v8/v9). It inherits global.tolerations but no node targeting,
-# so pin it explicitly to keep it on the glueops-platform nodes. (No-op on the
-# currently pinned 5.50.0 chart, which has no redisSecretInit component.)
-# @ignored
-redisSecretInit:
-  nodeSelector:
-    glueops.dev/role: "glueops-platform"
 redis-ha:
   image:
     repository: "ecr.repo.gpkg.io/docker/library/redis"
@@ -137,50 +131,11 @@ repoServer:
   pdb:
     enabled: true
     minAvailable: 2
-  nodeSelector:
-    glueops.dev/role: "glueops-platform"
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: argocd-repo-server
-          topologyKey: kubernetes.io/hostname
-      - weight: 50
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: app.kubernetes.io/name
-              operator: In
-              values:
-              - argocd-application-controller
-          topologyKey: kubernetes.io/hostname
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: "glueops.dev/role"
-            operator: In
-            values:
-            - "glueops-platform"
 # @ignored
 applicationSet:
   metrics:
     enabled: true
   replicas: 2
-  nodeSelector:
-    glueops.dev/role: "glueops-platform"
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: "glueops.dev/role"
-            operator: In
-            values:
-            - "glueops-platform"
 configs:
   params:
     server.insecure: true
@@ -245,19 +200,6 @@ configs:
       placeholder_argocd_rbac_policies
   # @ignored
 server:
-  # @ignored
-  nodeSelector:
-    glueops.dev/role: "glueops-platform"
-  # @ignored
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: "glueops.dev/role"
-            operator: In
-            values:
-            - "glueops-platform"
   # @ignored
   metrics:
     enabled: true

--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -62,6 +62,11 @@ redis-ha:
               values:
               - "glueops-platform"
   enabled: true
+  # nodeSelector applies to the redis-ha server, haproxy, AND the chart's
+  # helm-test pods (which only honor nodeSelector, not additionalAffinities),
+  # keeping every redis-ha pod on the glueops-platform nodes.
+  nodeSelector:
+    glueops.dev/role: "glueops-platform"
   tolerations:
     - key: "glueops.dev/role"
       operator: "Equal"


### PR DESCRIPTION
## What

Pin every ArgoCD pod to the `glueops.dev/role: glueops-platform` nodes using the chart's **`global.affinity`** preset instead of repeating a `nodeSelector` + `nodeAffinity` block on each component. Targets the deployed chart **9.x** (verified on 9.3.7 and 9.7.1). Net **−36 lines**.

## Change (single file: `argocd.yaml.tpl`)

- **`global`**: add
  ```yaml
  affinity:
    podAntiAffinity: soft
    nodeAffinity:
      type: hard              # -> requiredDuringSchedulingIgnoredDuringExecution
      matchExpressions:
        - {key: glueops.dev/role, operator: In, values: [glueops-platform]}
  ```
  (`global.tolerations` already carried the `glueops-platform` toleration.)
- **Removed** the per-component `nodeSelector` + `affinity` from `server`, `applicationSet`, `notifications`, `repoServer`, and deleted the `redisSecretInit` block — they now inherit `global`.

### Left overriding global on purpose
- **controller** — keeps its `affinity` (dedicated `glueops-platform-argocd-app-controller` pool preferred + `glueops-platform` fallback) and two-taint `tolerations`.
- **redis-ha** — subchart, not reachable by `global`; keeps `nodeSelector` + `tolerations` + `additionalAffinities` (also pins its helm-test pods).
- **gatekeeper** — raw `extraObjects` manifest; keeps its own `nodeSelector` + `tolerations`.

### Why not `global.nodeSelector`
It would AND onto the controller (whose `nodeSelector` is empty) and **exclude its dedicated pool** — a `nodeSelector` can't express the OR the controller's `nodeAffinity` does. So pinning is via `global.affinity.nodeAffinity`.

## Verification (`helm template`)

**11/11 pod-producing workloads pinned, 0 unpinned** on both 9.3.7 (deployed) and 9.7.1; controller keeps `req=[app-controller, glueops-platform]`, `pref=[app-controller]`, both tolerations. Independently reviewed by a Helm expert (approved).

## Behavior notes
- `server`/`applicationSet`/`notifications` gain a **soft own-pod host-spread** (from the global preset) — preferred-only, good for HA.
- `repoServer` loses the moot `weight:50` "spread off app-controller" term (controller lives on its own pool); own-pod spread preserved via the global soft preset.
- **Existing pods won't migrate** — `requiredDuringSchedulingIgnoredDuringExecution` is schedule-time only. After merge + Argo sync, `kubectl -n glueops-core rollout restart` the affected workloads so they reschedule. Ensure the `glueops-platform` pool has **≥3 nodes** (redis-ha's required host anti-affinity).
- `metrics.enabled` stays per-component (there is no `global.metrics`). No redis metrics changes.

## Follow-up (separate, not in this PR)
`README.md` still documents installing chart `5.50.0` while the cluster runs `9.3.7+` — worth a doc update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)