### PR TITLE
feat!: remove the Gate CRD from extraObjects (shipped by platform-crds)

### DIFF
--- a/argocd.yaml.tpl
+++ b/argocd.yaml.tpl
@@ -149,7 +149,7 @@ configs:
     application.resourceTrackingMethod: "annotation+label"
     # https://argo-cd.readthedocs.io/en/stable/operator-manual/health/#argocd-app
     # https://github.com/argoproj/argo-cd/issues/3781
-    # enables health check assessment for argocd applications as we are using sync-waves
+    # Application health assessment only takes effect for Applications that are children of another Application (e.g. tenant apps under captain-manifests); the platform chart's own Applications are created by Helm and have no parent.
     # @ignored
     resource.customizations.health.argoproj.io_Application: |
       hs = {}
@@ -260,105 +260,6 @@ extraObjects:
                     name: argocd-server
                     port:
                       number: 80
-
-  - apiVersion: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    metadata:
-      name: gates.platform.glueops.dev
-    spec:
-      group: platform.glueops.dev
-      scope: Namespaced
-      names:
-        plural: gates
-        singular: gate
-        kind: Gate
-        shortNames: ["gate"]
-      versions:
-        - name: v1alpha1
-          served: true
-          storage: true
-          subresources:
-            status: {}
-          schema:
-            openAPIV3Schema:
-              type: object
-              required: ["spec"]
-              properties:
-                spec:
-                  type: object
-                  required: ["checks"]
-                  properties:
-                    strict:
-                      type: boolean
-                      default: true
-                      description: "If true, the gate will be marked failed if any checks reference disallowed resource kinds or targets. If false, such checks will be ignored but the gate can still pass if all other checks pass."
-                    checks:
-                      type: array
-                      minItems: 1
-                      items:
-                        type: object
-                        required: ["id"]
-                        properties:
-                          id:
-                            type: string
-                            minLength: 1
-                            maxLength: 63
-                          namespace:
-                            type: string
-                            minLength: 1
-                            maxLength: 63
-                          deploymentAvailable:
-                            type: object
-                            required: ["name"]
-                            properties:
-                              name: { type: string, minLength: 1 }
-                              minAvailableReplicas: { type: integer, minimum: 0, default: 1 }
-                          statefulSetReady:
-                            type: object
-                            required: ["name"]
-                            properties:
-                              name: { type: string, minLength: 1 }
-                              minReadyReplicas: { type: integer, minimum: 0, default: 1 }
-                              requireUpdatedRevision: { type: boolean, default: true }
-                          jobComplete:
-                            type: object
-                            required: ["name"]
-                            properties:
-                              name: { type: string, minLength: 1 }
-                          serviceReadyEndpoints:
-                            type: object
-                            required: ["name"]
-                            properties:
-                              name: { type: string, minLength: 1 }
-                              minReadyAddresses: { type: integer, minimum: 0, default: 1 }
-                          podLabelReady:
-                            type: object
-                            required: ["selector"]
-                            properties:
-                              selector: { type: string, minLength: 1 }
-                              minReadyPods: { type: integer, minimum: 0, default: 1 }
-                          argoApplicationHealthy:
-                            type: object
-                            required: ["name"]
-                            properties:
-                              name: { type: string, minLength: 1 }
-                              requireSynced: { type: boolean, default: true }
-                              requireHealthy: { type: boolean, default: true }
-                status:
-                  type: object
-                  properties:
-                    observedGeneration: { type: integer }
-                    ready: { type: boolean }
-                    lastEvaluatedTime: { type: string, format: date-time }
-                    results:
-                      type: array
-                      items:
-                        type: object
-                        required: ["id", "ready"]
-                        properties:
-                          id: { type: string }
-                          ready: { type: boolean }
-                          message: { type: string }
 
   - apiVersion: v1
     kind: Namespace


### PR DESCRIPTION
## Summary

Platform CRDs are moving to a layer-0 bundle: the new `GlueOps/platform-crds` OCI chart is applied by `captain_utils → crds` with server-side apply **before** the argocd release and before the platform chart, and no Helm release or ArgoCD Application renders a CRD any more. The `gates.platform.glueops.dev` CustomResourceDefinition was the one CRD still shipped by the argocd release (`extraObjects`); this PR removes it so the bundle is the single owner of that object (plan decision 7).

The gatekeeper workload itself (Namespace, ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, Service) and the `argocd-server-api` Ingress stay in `extraObjects`. `crds.install: false` stays: ArgoCD's own CRDs also come from the bundle.

While in the file, the comment above the `argoproj.io_Application` health customization is reworded: that customization only takes effect for Applications that are children of another Application (tenant apps under captain-manifests); the platform chart's own Applications are created by Helm and have no parent, so the previous "we are using sync-waves" rationale was misleading.

## Changes

- `argocd.yaml.tpl`
  - Remove the `apiextensions.k8s.io/v1` `CustomResourceDefinition` `gates.platform.glueops.dev` entry from `extraObjects` (99 lines: the whole entry through the end of its `status` schema). `extraObjects` goes from 8 entries to 7; no other entry is touched.
  - Reword the comment on the `resource.customizations.health.argoproj.io_Application` block (was: `# enables health check assessment for argocd applications as we are using sync-waves`).
  - No other changes; `crds.install: false` is unchanged.

## Verification

Run from the repo root on this branch (yq v4.53.3, OpenTofu v1.11.11 as `terraform`):

```
$ yq '.extraObjects | length' argocd.yaml.tpl          # on main
8
$ yq '.extraObjects | length' argocd.yaml.tpl          # on this branch
7
$ yq -e '[.extraObjects[] | select(.kind == "CustomResourceDefinition")] | length == 0' argocd.yaml.tpl
true
$ yq -e '.extraObjects | map(.kind) | contains(["CustomResourceDefinition"]) | not' argocd.yaml.tpl
true
$ yq -e '.crds.install == false' argocd.yaml.tpl
true
$ yq '.extraObjects[] | .kind + "/" + .metadata.name' argocd.yaml.tpl
Ingress/argocd-server-api
Namespace/glueops-core-gatekeeper
ServiceAccount/glueops-core-gatekeeper
ClusterRole/glueops-core-gatekeeper
ClusterRoleBinding/glueops-core-gatekeeper
Deployment/gatekeeper
Service/gatekeeper
$ grep -c gates.platform.glueops.dev argocd.yaml.tpl
0
$ terraform init -backend=false && terraform validate
Success! The configuration is valid.
$ git diff --stat main
 argocd.yaml.tpl | 101 +-------------------------------------------------------
 1 file changed, 1 insertion(+), 100 deletions(-)
```

(The planned check `yq -e '.extraObjects | map(.kind) | index("CustomResourceDefinition") == null'` does not parse in mikefarah yq v4 (`index` is not an operator there); the two `select`/`contains` forms above are the equivalent and both pass.)

## Notes for the reviewer

- **BREAKING for existing clusters.** Helm owns the live `gates.platform.glueops.dev` CRD today, so the next `helm upgrade` of the argocd release with these values **deletes** it. No Gate resources exist in prod, so nothing is garbage-collected. The `captain_utils crds` step must run again after the argocd upgrade to recreate the CRD from the bundle; gatekeeper does not crash while the CRD is absent (it uses a per-request dynamic client). Sequence per cluster: `crds → argocd → crds → glueops-platform`.
- **Ordering across repos.** This release must not be consumed by a cluster before the `platform-crds` bundle exists and the `captain_utils` `crds` step (GlueOps/codespaces) is available; the terraform module (`terraform-module-cloud-multy-prerequisites`) bump that picks up this docs-argocd release should land together with the `platform_crds_version` pin so a single module `?ref=` bump carries both. Roll out nonprod first.
- **Rollback caveat.** Rolling the module `?ref=` back below this release regenerates `argocd.yaml` with the CRD in `extraObjects` again; `helm upgrade argocd` would then fail Helm's ownership pre-flight (`exists and cannot be imported into the current release`) because the bundle owns the CRD. Skip the argocd step in that case, or run once by hand with `--take-ownership`. Never `helm rollback argocd` to a pre-migration revision.
- Commit is `feat!:` so release-please cuts a **minor** bump (release-please-config.json has bump-minor-pre-major: true, so this lands as v0.20.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uDhM6cLPHUeRb7GFNo96c

